### PR TITLE
added plugin descriptors to allow plugins to be referenced by ID rather than class name

### DIFF
--- a/src/main/resources/META-INF/gradle-plugins/sjit.all.properties
+++ b/src/main/resources/META-INF/gradle-plugins/sjit.all.properties
@@ -1,0 +1,1 @@
+implementation-class=com.smokejumperit.gradle.AllPlugins

--- a/src/main/resources/META-INF/gradle-plugins/sjit.classloaders.properties
+++ b/src/main/resources/META-INF/gradle-plugins/sjit.classloaders.properties
@@ -1,0 +1,1 @@
+implementation-class=com.smokejumperit.gradle.ClassLoadersPlugin

--- a/src/main/resources/META-INF/gradle-plugins/sjit.cuke.properties
+++ b/src/main/resources/META-INF/gradle-plugins/sjit.cuke.properties
@@ -1,0 +1,1 @@
+implementation-class=com.smokejumperit.gradle.CukePlugin

--- a/src/main/resources/META-INF/gradle-plugins/sjit.depnames.properties
+++ b/src/main/resources/META-INF/gradle-plugins/sjit.depnames.properties
@@ -1,0 +1,1 @@
+implementation-class=com.smokejumperit.gradle.DepNamesPlugin

--- a/src/main/resources/META-INF/gradle-plugins/sjit.env.properties
+++ b/src/main/resources/META-INF/gradle-plugins/sjit.env.properties
@@ -1,0 +1,1 @@
+implementation-class=com.smokejumperit.gradle.EnvPlugin

--- a/src/main/resources/META-INF/gradle-plugins/sjit.exec.properties
+++ b/src/main/resources/META-INF/gradle-plugins/sjit.exec.properties
@@ -1,0 +1,1 @@
+implementation-class=com.smokejumperit.gradle.ExecPlugin

--- a/src/main/resources/META-INF/gradle-plugins/sjit.javacc.properties
+++ b/src/main/resources/META-INF/gradle-plugins/sjit.javacc.properties
@@ -1,0 +1,1 @@
+implementation-class=com.smokejumperit.gradle.JavaccPlugin

--- a/src/main/resources/META-INF/gradle-plugins/sjit.mavenproxy.properties
+++ b/src/main/resources/META-INF/gradle-plugins/sjit.mavenproxy.properties
@@ -1,0 +1,1 @@
+implementation-class=com.smokejumperit.gradle.MavenProxyPlugin

--- a/src/main/resources/META-INF/gradle-plugins/sjit.onejar.properties
+++ b/src/main/resources/META-INF/gradle-plugins/sjit.onejar.properties
@@ -1,0 +1,1 @@
+implementation-class=com.smokejumperit.gradle.OneJarPlugin

--- a/src/main/resources/META-INF/gradle-plugins/sjit.projectext.properties
+++ b/src/main/resources/META-INF/gradle-plugins/sjit.projectext.properties
@@ -1,0 +1,1 @@
+implementation-class=com.smokejumperit.gradle.ProjectExtPlugin

--- a/src/main/resources/META-INF/gradle-plugins/sjit.runjruby.properties
+++ b/src/main/resources/META-INF/gradle-plugins/sjit.runjruby.properties
@@ -1,0 +1,1 @@
+implementation-class=com.smokejumperit.gradle.RunJRubyPlugin


### PR DESCRIPTION
Apart from being easier to read and write, IDs avoid problems like http://jira.codehaus.org/browse/GRADLE-1352
