### PR TITLE
ExecPlugin bug?

### DIFF
--- a/src/main/groovy/ExecPlugin.groovy
+++ b/src/main/groovy/ExecPlugin.groovy
@@ -10,7 +10,7 @@ class ExecPlugin extends SjitPlugin {
       delegate.exec(cmd, new File(baseDir))
     }
     project.metaClass.exec = { String cmd, File baseDir=new File('.') ->
-			project.execIn(baseDir, cmd)
+			project.execIn(baseDir, cmd.split())
 		}
 		project.metaClass.execIn = { File baseDir, Object... cmd ->
 			project.execIn(baseDir, cmd*.toString() as String[])


### PR DESCRIPTION
Hi there Mr Fischer,

Before I start running off my mouth, I should make it clear that I am a C systems/network programmer with absolutely no experience with Java or Groovy, so if I'm completely misapplying the API, please forgive this intrusion. I'm trying to use Gradle as an element in my company's build/deploy/release system and I was having trouble getting the ExecPlugin to do anything other than throw exceptions. In the end, I wound up forking my own copy (obviously) and adding more logging. It certainly seemed from what my logs said as well as the error messages that ultimately, down in the deep depths of the JVM the plugin was making the classic mistake of passing execve() the full string instead split up in the way that execve() wishes. Since quick strace(1)  confirmed this _and_ it seemed clear that execIn() wanted a String array anyhow (not surprisingly), I made the change I'm suggesting in this pull request. 
