### PR TITLE
Change to update your Gradle OneJar plugin to work with newer Gradle versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,20 +10,19 @@ configurations {
 
 
 configure(install.repositories.mavenInstaller) {
-	pom.project {
-		groupId 'com.smokejumperit'
-		artifactId 'gradle-plugins'
-		version project.version
-	}
+  pom.project {
+    groupId 'com.smokejumperit'
+    artifactId 'gradle-plugins'
+    version project.version
+  }
 }
-
 
 ant.property(environment:'env')
 if(!ant.properties['env.GRADLE_HOME']) throw new Exception('Please set $GRADLE_HOME')
 
 repositories {
   mavenCentral()
-  mavenRepo urls:'http://repo.smokejumperit.com'
+  maven { url 'http://repo.smokejumperit.com' }
 }
 dependencies {
   groovy 'org.codehaus.groovy:groovy:1.8.0'
@@ -35,15 +34,15 @@ dependencies {
 }
 
 processResources {
-	includes = excludes = []
-	include "**/*"
-	exclude "**/.gitignore"
+  includes = excludes = []
+  include "**/*"
+  exclude "**/.gitignore"
 }
 
 jar {
-	includes = excludes = []
-	include "**/*"
-	exclude "**/.gitignore"
+  includes = excludes = []
+  include "**/*"
+  exclude "**/.gitignore"
 }
 
 uploadArchives { 

--- a/src/main/groovy/OneJarPlugin.groovy
+++ b/src/main/groovy/OneJarPlugin.groovy
@@ -97,7 +97,7 @@ class OneJarPlugin extends SjitPlugin {
 
 				Date date = new Date()
 				String name = jar.baseName
-				project.configurations.archives.addArtifact(
+				project.artifacts.add('archives',
 					[
 						getClassifier: { -> "standalone" },
 						getDate: {-> date },


### PR DESCRIPTION
## These plugins now build with a more recent Gradle (1.0M7) as long as Code Narc is turned off (-x codenarcMain). And I've tested that the OneJar plugin now runs correctly and produces a working jar.

Updated Gradle build file to eliminate warnings when building with Gradle 1.0-M7.

Fixed an internal call in the OneJar plugin to use newer artifact management API.
