### PR TITLE
Clean-ups and fixes for OneJar

### DIFF
--- a/src/main/groovy/OneJarPlugin.groovy
+++ b/src/main/groovy/OneJarPlugin.groovy
@@ -82,10 +82,6 @@ class OneJarPlugin extends SjitPlugin {
 							ant.fileset(dir:depDir.absolutePath)
 						}
 					}
-					project.sourceSets*.resources*.getSrcDirs()?.flatten()?.findAll { it?.exists() }?.each { resdir ->
-						project.logger.debug("Adding ${resdir.absolutePath} to OneJar top-level (for resources)")
-						ant.fileset(dir:resdir.absolutePath)
-					}
 					ant.lib {
 						runtimeLibs.each { depFile ->
 							project.logger.debug("Adding ${depFile.absolutePath} to OneJar lib")

--- a/src/main/groovy/OneJarPlugin.groovy
+++ b/src/main/groovy/OneJarPlugin.groovy
@@ -68,10 +68,12 @@ class OneJarPlugin extends SjitPlugin {
 				project.logger.debug("Runtime files to consider for OneJar (${runConf.size()}):\n\t${runConf.join("\n\t")}")
 				def (runtimeDirs, runtimeLibs) = runConf.split { it.isDirectory() }
 
-				System.setProperty("one-jar.verbose", "${false}")
-				System.setProperty("one-jar.info", "${false}")
-				System.setProperty("one-jar.statistics", "${false}")
-				System.setProperty("one-jar.show.properties", "${false}")
+				if (logger.isEnabled(org.gradle.api.logging.LogLevel.DEBUG)) {
+					System.setProperty("one-jar.verbose", "true")
+					System.setProperty("one-jar.info", "true")
+					System.setProperty("one-jar.statistics", "true")
+					System.setProperty("one-jar.show.properties", "true")
+				}
 				def manifestFile = writeOneJarManifestFile(jar) 
 				ant.'one-jar'(destFile:jarFile.absolutePath, manifest:manifestFile.absolutePath) {
 					ant.main(jar:jar.archivePath.absolutePath) {


### PR DESCRIPTION
Some improvements to the OneJar plugin: 
- Don't need to add resources to OneJar (they are already contained in jar file, but adding these also adds the "test" resources).
- Only use "runtime" configuration
- Enable verbose output for OneJar if gradle debugging is enabled.
